### PR TITLE
Add gitignores for metals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,11 @@
 .idea
 *.iml
 .vscode
+.metals
+.bloop
 
 # Scala related files
+scala/project
 scala/target
 scala/project/target/
 scala/project/project/target/


### PR DESCRIPTION
Avoid checking in lots of temp files created by the metals vscode extension.