### PR TITLE
Update for spark 3.5.0

### DIFF
--- a/python/ackuq/pit/context.py
+++ b/python/ackuq/pit/context.py
@@ -25,7 +25,7 @@
 from typing import Any, List, Optional, Tuple
 
 from py4j.java_gateway import JavaPackage
-from pyspark.sql import Column, DataFrame, SQLContext
+from pyspark.sql import Column, DataFrame, SparkSession
 from pyspark.sql.column import _to_java_column, _to_seq  # type: ignore
 from pyspark.sql.functions import lit
 
@@ -39,7 +39,7 @@ class PitContext(object):
     def _init_early_stop_sort_merge(self) -> None:
         # Call the init function in the Scala object,
         # will register the strategies and rules
-        self._essm.init(self._sql_context.sparkSession._jsparkSession)  # type: ignore
+        self._essm.init(self._spark._jsparkSession)  # type: ignore
 
     CLASSPATH_ERROR_MSG = (
         "Java class {} could not be imported, check that it is included in the JVM"
@@ -67,9 +67,9 @@ class PitContext(object):
                 self.CLASSPATH_ERROR_MSG.format("io.github.ackuq.pit.Exploding")
             )
 
-    def __init__(self, sql_context: SQLContext) -> None:
-        self._sql_context = sql_context
-        self._sc = self._sql_context._sc  # type: ignore
+    def __init__(self, spark: SparkSession) -> None:
+        self._spark = spark
+        self._sc = self._spark.sparkContext
         self._jsc = self._sc._jsc
         self._jvm = self._sc._jvm
 

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -44,8 +44,7 @@ class SparkTests(unittest.TestCase):
             .config("spark.sql.shuffle.partitions", 1)
             .getOrCreate()
         )
-        self.sql_context = SQLContext(self.spark.sparkContext)
-        self.pit_context = PitContext(self.sql_context)
+        self.pit_context = PitContext(self.spark)
 
     def tearDown(self) -> None:
         self.spark.stop()

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -12,8 +12,8 @@ lazy val root = (project in file("."))
   )
 
 libraryDependencies ++= Seq(
-  "org.apache.spark" %% "spark-core" % "3.2.1" % "provided",
-  "org.apache.spark" %% "spark-sql" % "3.2.1" % "provided",
+  "org.apache.spark" %% "spark-core" % "3.5.0" % "provided",
+  "org.apache.spark" %% "spark-sql" % "3.5.0" % "provided",
   "org.scalactic" %% "scalactic" % "3.2.12",
   "org.scalatest" %% "scalatest" % "3.2.12" % "test"
 )

--- a/scala/src/main/scala/EarlyStopSortMerge.scala
+++ b/scala/src/main/scala/EarlyStopSortMerge.scala
@@ -48,7 +48,7 @@ object EarlyStopSortMerge {
       spark.experimental.extraStrategies =
         spark.experimental.extraStrategies :+ CustomStrategy
     }
-    if (!spark.experimental.extraStrategies.contains(PITRule)) {
+    if (!spark.experimental.extraOptimizations.contains(PITRule)) {
       spark.experimental.extraOptimizations =
         spark.experimental.extraOptimizations :+ PITRule
     }

--- a/scala/src/main/scala/execution/PITJoinExec.scala
+++ b/scala/src/main/scala/execution/PITJoinExec.scala
@@ -75,7 +75,7 @@ protected[pit] case class PITJoinExec(
       // TODO: This should be improved, but for now just keep everything in one partition
       AllTuples :: AllTuples :: Nil
     } else {
-      HashClusteredDistribution(leftEquiKeys) :: HashClusteredDistribution(
+      ClusteredDistribution(leftEquiKeys) :: ClusteredDistribution(
         rightEquiKeys
       ) :: Nil
     }


### PR DESCRIPTION
- Build against Spark 3.5.0
- Fix due to `HashClusteredDistribution` being replaced by `ClusteredDistribution` with the release of spark 3.3.0.
- Fix initialising extra strategies to ensure the strategy is not re-added every time `EarlyStopSortMerge.init()` is called. 
- Switch the python side to use `SparkSession` because `SQLContext` is deprecated. I also found some strange casting error when using `SQLContext`, depending on how I used the spark session prior to running the merge. 
```
Caused by: java.lang.ClassCastException: class java.lang.Long cannot be cast to class org.apache.spark.sql.Column (java.lang.Long is in module java.base of loader 'bootstrap'; org.apache.spark.sql.Column is in unnamed module of loader 'app')
```