### PR TITLE
Fix correctness bugs 

### DIFF
--- a/scala/src/main/scala/execution/PITJoinExec.scala
+++ b/scala/src/main/scala/execution/PITJoinExec.scala
@@ -778,7 +778,10 @@ protected[pit] class PITJoinScanner(
       matchJoinEquiKey = null
       matchJoinPITKey = null
       bufferedMatch = null
-      false
+      // If not returnNulls then we can exit early without searching through the remainder of the 
+      // streamed row. If returnNulls then it doesn't matter that there are no more candidate rows
+      // to match with - we still need to return the streamed row so they can be matched with nulls. 
+      returnNulls
     } else {
       // Advance both the streamed and buffered iterators to find the next pair of matching rows.
       var equiComp =

--- a/scala/src/main/scala/execution/PITJoinExec.scala
+++ b/scala/src/main/scala/execution/PITJoinExec.scala
@@ -493,6 +493,7 @@ protected[pit] case class PITJoinExec(
          |    do {
          |      if($rightRow == null) {
          |        if(!rightIter.hasNext()) {
+         |          $matched = null;
          |          return false;
          |        }
          |        $rightRow = (InternalRow) rightIter.next();

--- a/scala/src/test/scala/EarlyStopMergeTests.scala
+++ b/scala/src/test/scala/EarlyStopMergeTests.scala
@@ -278,6 +278,32 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
     )
   }
 
+  testBothCodegenAndInterpreted(
+    "inner_join_preserves_input_nulls"
+  ) {
+    testSearchingBackwardForMatches(
+      "inner",
+      smallData.fg3_with_nulls,
+      smallData.fg1_with_nulls,
+      smallData.PIT_3_1_WITH_NULLS,
+      smallData.PIT_2_NULLABLE_schema,
+      0
+    )
+  }
+
+  testBothCodegenAndInterpreted(
+    "left_join_preserves_input_nulls"
+  ) {
+    testSearchingBackwardForMatches(
+      "left",
+      smallData.fg3_with_nulls,
+      smallData.fg1_with_nulls,
+      smallData.PIT_3_1_WITH_NULLS_OUTER,
+      smallData.PIT_2_NULLABLE_OUTER_schema,
+      0
+    )
+  }
+
   def testJoiningThreeDataframes(
       joinType: String,
       expectedSchema: StructType

--- a/scala/src/test/scala/EarlyStopMergeTests.scala
+++ b/scala/src/test/scala/EarlyStopMergeTests.scala
@@ -65,7 +65,6 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
         joinType
       )
 
-    assert(!pitJoin.isEmpty)
     assert(pitJoin.schema.equals(expectedSchema))
     assert(pitJoin.collect().sameElements(smallData.PIT_1_2.collect()))
   }
@@ -102,6 +101,9 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
       expectedSchema: StructType,
       tolerance: Int
   ): Unit = {
+    leftDataFrame.show()
+    rightDataFrame.show()
+
     val pitJoin =
       leftDataFrame.join(
         rightDataFrame,
@@ -113,7 +115,9 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
         joinType
       )
 
-    assert(!pitJoin.isEmpty)
+    pitJoin.show()
+    expectedDataFrame.show()
+
     assert(pitJoin.schema.equals(expectedSchema))
     assert(pitJoin.collect().sameElements(expectedDataFrame.collect()))
   }
@@ -191,6 +195,84 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
       smallData.fg3,
       smallData.fg1,
       smallData.PIT_3_1_OUTER,
+      smallData.PIT_2_OUTER_schema,
+      0
+    )
+  }
+
+  testBothCodegenAndInterpreted(
+    "inner_join_right_dataframe_is_empty"
+  ) {
+    testSearchingBackwardForMatches(
+      "inner",
+      smallData.fg1,
+      smallData.empty,
+      smallData.PIT_EMPTY,
+      smallData.PIT_2_schema,
+      0
+    )
+  }
+
+  testBothCodegenAndInterpreted(
+    "left_join_right_dataframe_is_empty"
+  ) {
+    testSearchingBackwardForMatches(
+      "left",
+      smallData.fg1,
+      smallData.empty,
+      smallData.PIT_1_EMPTY_OUTER,
+      smallData.PIT_2_OUTER_schema,
+      0
+    )
+  }
+
+  testBothCodegenAndInterpreted(
+    "inner_join_left_dataframe_is_empty"
+  ) {
+    testSearchingBackwardForMatches(
+      "inner",
+      smallData.fg1,
+      smallData.empty,
+      smallData.PIT_EMPTY,
+      smallData.PIT_2_schema,
+      0
+    )
+  }
+
+  testBothCodegenAndInterpreted(
+    "left_join_left_dataframe_is_empty"
+  ) {
+    testSearchingBackwardForMatches(
+      "left",
+      smallData.empty,
+      smallData.fg1,
+      smallData.PIT_EMPTY,
+      smallData.PIT_2_OUTER_schema,
+      0
+    )
+  }
+
+  testBothCodegenAndInterpreted(
+    "inner_join_both_dataframes_are_empty"
+  ) {
+    testSearchingBackwardForMatches(
+      "inner",
+      smallData.empty,
+      smallData.empty2,  // Don't want to test self join
+      smallData.PIT_EMPTY,
+      smallData.PIT_2_schema,
+      0
+    )
+  }
+
+  testBothCodegenAndInterpreted(
+    "left_join_both_dataframes_are_empty"
+  ) {
+    testSearchingBackwardForMatches(
+      "left",
+      smallData.empty,
+      smallData.empty2, // Don't want to test self join
+      smallData.PIT_EMPTY,
       smallData.PIT_2_OUTER_schema,
       0
     )

--- a/scala/src/test/scala/EarlyStopMergeTests.scala
+++ b/scala/src/test/scala/EarlyStopMergeTests.scala
@@ -50,49 +50,6 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
     }
   }
 
-  def testJoinWithAlignedTimestamps(
-      joinType: String,
-      expectedSchema: StructType,
-      tolerance: Int
-  ): Unit = {
-    val fg1 = smallData.fg1
-    val fg2 = smallData.fg2
-
-    val pitJoin =
-      fg1.join(
-        fg2,
-        pit(fg1("ts"), fg2("ts"), lit(tolerance)) && fg1("id") === fg2("id"),
-        joinType
-      )
-
-    assert(pitJoin.schema.equals(expectedSchema))
-    assert(pitJoin.collect().sameElements(smallData.PIT_1_2.collect()))
-  }
-
-  testBothCodegenAndInterpreted(
-    "inner_join_with_aligned_timestamps_no_tolerance"
-  ) {
-    testJoinWithAlignedTimestamps("inner", smallData.PIT_2_schema, 0)
-  }
-
-  testBothCodegenAndInterpreted(
-    "left_join_with_aligned_timestamps_no_tolerance"
-  ) {
-    testJoinWithAlignedTimestamps("left", smallData.PIT_2_OUTER_schema, 0)
-  }
-
-  testBothCodegenAndInterpreted(
-    "inner_join_with_aligned_timestamps_with_tolerance"
-  ) {
-    testJoinWithAlignedTimestamps("inner", smallData.PIT_2_schema, 1)
-  }
-
-  testBothCodegenAndInterpreted(
-    "left_join_with_aligned_timestamps_with_tolerance"
-  ) {
-    testJoinWithAlignedTimestamps("left", smallData.PIT_2_OUTER_schema, 1)
-  }
-
   def testSearchingBackwardForMatches(
       joinType: String,
       leftDataFrame: DataFrame,
@@ -120,6 +77,58 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
 
     assert(pitJoin.schema.equals(expectedSchema))
     assert(pitJoin.collect().sameElements(expectedDataFrame.collect()))
+  }
+
+  testBothCodegenAndInterpreted(
+    "inner_join_with_aligned_timestamps_no_tolerance"
+  ) {
+    testSearchingBackwardForMatches(
+      "inner",
+      smallData.fg1,
+      smallData.fg2,
+      smallData.PIT_1_2,
+      smallData.PIT_2_schema,
+      0
+    )
+  }
+
+  testBothCodegenAndInterpreted(
+    "left_join_with_aligned_timestamps_no_tolerance"
+  ) {
+    testSearchingBackwardForMatches(
+      "left",
+      smallData.fg1,
+      smallData.fg2,
+      smallData.PIT_1_2,
+      smallData.PIT_2_OUTER_schema,
+      0
+    )
+  }
+
+  testBothCodegenAndInterpreted(
+    "inner_join_with_aligned_timestamps_with_tolerance"
+  ) {
+    testSearchingBackwardForMatches(
+      "inner",
+      smallData.fg1,
+      smallData.fg2,
+      smallData.PIT_1_2,
+      smallData.PIT_2_schema,
+      1
+    )
+  }
+
+  testBothCodegenAndInterpreted(
+    "left_join_with_aligned_timestamps_with_tolerance"
+  ) {
+    testSearchingBackwardForMatches(
+      "left",
+      smallData.fg1,
+      smallData.fg2,
+      smallData.PIT_1_2,
+      smallData.PIT_2_OUTER_schema,
+      1
+    )
   }
 
   testBothCodegenAndInterpreted(

--- a/scala/src/test/scala/EarlyStopMergeTests.scala
+++ b/scala/src/test/scala/EarlyStopMergeTests.scala
@@ -36,15 +36,15 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
   val smallData = new SmallDataSortMerge(spark)
 
   def testBothCodegenAndInterpreted(name: String)(f: => Unit): Unit = {
-    it should (s"$name with codegen") in {
-      spark.conf.set("spark.sql.codegen.wholeStage", "false")
-      spark.conf.set("spark.sql.codegen.factoryMode", "NO_CODEGEN")
+    it should (s"codegen__$name") in {
+      spark.conf.set("spark.sql.codegen.wholeStage", "true")
+      spark.conf.set("spark.sql.codegen.factoryMode", "CODEGEN_ONLY")
       f
     }
 
-    it should (s"$name interpreted") in {
-      spark.conf.set("spark.sql.codegen.wholeStage", "true")
-      spark.conf.set("spark.sql.codegen.factoryMode", "CODEGEN_ONLY")
+    it should (s"interpreted__$name") in {
+      spark.conf.set("spark.sql.codegen.wholeStage", "false")
+      spark.conf.set("spark.sql.codegen.factoryMode", "NO_CODEGEN")
       f
     }
   }

--- a/scala/src/test/scala/EarlyStopMergeTests.scala
+++ b/scala/src/test/scala/EarlyStopMergeTests.scala
@@ -170,6 +170,32 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
     )
   }
 
+  testBothCodegenAndInterpreted(
+    "inner_join_some_rows_have_no_backwards_match"
+  ) {
+    testSearchingBackwardForMatches(
+      "inner",
+      smallData.fg3,
+      smallData.fg1,
+      smallData.PIT_3_1,
+      smallData.PIT_2_schema,
+      0
+    )
+  }
+
+  testBothCodegenAndInterpreted(
+    "left_join_some_rows_have_no_backwards_match"
+  ) {
+    testSearchingBackwardForMatches(
+      "left",
+      smallData.fg3,
+      smallData.fg1,
+      smallData.PIT_3_1_OUTER,
+      smallData.PIT_2_OUTER_schema,
+      0
+    )
+  }
+
   def testJoiningThreeDataframes(
       joinType: String,
       expectedSchema: StructType

--- a/scala/src/test/scala/EarlyStopMergeTests.scala
+++ b/scala/src/test/scala/EarlyStopMergeTests.scala
@@ -258,7 +258,7 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
     testSearchingBackwardForMatches(
       "inner",
       smallData.empty,
-      smallData.empty2,  // Don't want to test self join
+      smallData.empty2, // Don't want to test self join
       smallData.PIT_EMPTY,
       smallData.PIT_2_schema,
       0
@@ -301,6 +301,32 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
       smallData.PIT_3_1_WITH_NULLS_OUTER,
       smallData.PIT_2_NULLABLE_OUTER_schema,
       0
+    )
+  }
+
+  testBothCodegenAndInterpreted(
+    "inner_join_preserves_input_nulls_with_tolerance"
+  ) {
+    testSearchingBackwardForMatches(
+      "inner",
+      smallData.fg3_with_nulls,
+      smallData.fg1_with_nulls,
+      smallData.PIT_3_1_T1_WITH_NULLS,
+      smallData.PIT_2_NULLABLE_schema,
+      1
+    )
+  }
+
+  testBothCodegenAndInterpreted(
+    "left_join_preserves_input_nulls_with_tolerance"
+  ) {
+    testSearchingBackwardForMatches(
+      "left",
+      smallData.fg3_with_nulls,
+      smallData.fg1_with_nulls,
+      smallData.PIT_3_1_T1_WITH_NULLS_OUTER,
+      smallData.PIT_2_NULLABLE_OUTER_schema,
+      1
     )
   }
 

--- a/scala/src/test/scala/EarlyStopMergeTests.scala
+++ b/scala/src/test/scala/EarlyStopMergeTests.scala
@@ -58,8 +58,6 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
       expectedSchema: StructType,
       tolerance: Int
   ): Unit = {
-    leftDataFrame.show()
-    rightDataFrame.show()
 
     val pitJoin =
       leftDataFrame.join(
@@ -71,9 +69,6 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
         ) && leftDataFrame("id") === rightDataFrame("id"),
         joinType
       )
-
-    pitJoin.show()
-    expectedDataFrame.show()
 
     assert(pitJoin.schema.equals(expectedSchema))
     assert(pitJoin.collect().sameElements(expectedDataFrame.collect()))
@@ -361,7 +356,6 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
         joinType
       )
 
-    assert(!pitJoin.isEmpty)
     assert(pitJoin.schema.equals(expectedSchema))
     assert(pitJoin.collect().sameElements(smallData.PIT_1_2_3.collect()))
   }

--- a/scala/src/test/scala/SparkSessionTestWrapper.scala
+++ b/scala/src/test/scala/SparkSessionTestWrapper.scala
@@ -34,4 +34,6 @@ trait SparkSessionTestWrapper {
     .config("spark.ui.showConsoleProgress", value = false)
     .config("spark.sql.shuffle.partitions", 1)
     .getOrCreate()
+
+  spark.sparkContext.setLogLevel("ERROR")
 }

--- a/scala/src/test/scala/data/SmallData.scala
+++ b/scala/src/test/scala/data/SmallData.scala
@@ -71,4 +71,10 @@ class SmallData(spark: SparkSession) {
     spark.createDataFrame(spark.sparkContext.parallelize(DATA_RAW(1)), schema)
   val fg3: DataFrame =
     spark.createDataFrame(spark.sparkContext.parallelize(DATA_RAW(2)), schema)
+
+  val empty: DataFrame =
+    spark.createDataFrame(spark.sparkContext.emptyRDD[Row], schema)
+
+  val empty2: DataFrame =
+    spark.createDataFrame(spark.sparkContext.emptyRDD[Row], schema)
 }

--- a/scala/src/test/scala/data/SmallData.scala
+++ b/scala/src/test/scala/data/SmallData.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.types.{
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 
 class SmallData(spark: SparkSession) {
-  private val DATA_RAW = Seq(
+  val DATA_RAW = Seq(
     Seq(
       Row(1, 4, "1z"),
       Row(1, 5, "1x"),
@@ -57,7 +57,7 @@ class SmallData(spark: SparkSession) {
       Row(1, 10, "f3-1-10")
     )
   )
-  private val schema: StructType = StructType(
+  val schema: StructType = StructType(
     Seq(
       StructField("id", IntegerType, nullable = false),
       StructField("ts", IntegerType, nullable = false),

--- a/scala/src/test/scala/data/SmallData.scala
+++ b/scala/src/test/scala/data/SmallData.scala
@@ -25,37 +25,42 @@
 package io.github.ackuq.pit
 package data
 
-import org.apache.spark.sql.types.{
-  IntegerType,
-  StringType,
-  StructField,
-  StructType
-}
-import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.types.StringType
+import org.apache.spark.sql.types.StructField
+import org.apache.spark.sql.types.StructType
 
 class SmallData(spark: SparkSession) {
-  val DATA_RAW = Seq(
-    Seq(
-      Row(1, 4, "1z"),
-      Row(1, 5, "1x"),
-      Row(2, 6, "2x"),
-      Row(1, 7, "1y"),
-      Row(2, 8, "2y")
-    ),
-    Seq(
-      Row(1, 4, "1z"),
-      Row(1, 5, "1x"),
-      Row(2, 6, "2x"),
-      Row(1, 7, "1y"),
-      Row(2, 8, "2y")
-    ),
-    Seq(
-      Row(1, 1, "f3-1-1"),
-      Row(2, 2, "f3-2-2"),
-      Row(1, 6, "f3-1-6"),
-      Row(2, 8, "f3-2-8"),
-      Row(1, 10, "f3-1-10")
-    )
+  val RAW_1 = Seq(
+    Row(1, 4, "1z"),
+    Row(1, 5, "1x"),
+    Row(2, 6, "2x"),
+    Row(1, 7, "1y"),
+    Row(2, 8, "2y")
+  )
+  val RAW_1_WITH_NULLS = Seq(
+    Row(1, 4, "1z"),
+    Row(1, 5, null),
+    Row(2, 6, "2x"),
+    Row(1, 7, "1y"),
+    Row(2, 8, "2y")
+  )
+  val RAW_3 = Seq(
+    Row(1, 1, "f3-1-1"),
+    Row(2, 2, "f3-2-2"),
+    Row(1, 6, "f3-1-6"),
+    Row(2, 8, "f3-2-8"),
+    Row(1, 10, "f3-1-10")
+  )
+  val RAW_3_WITH_NULLS = Seq(
+    Row(1, 1, "f3-1-1"),
+    Row(2, 2, "f3-2-2"),
+    Row(1, 6, "f3-1-6"),
+    Row(2, 8, null),
+    Row(1, 10, "f3-1-10")
   )
   val schema: StructType = StructType(
     Seq(
@@ -64,13 +69,30 @@ class SmallData(spark: SparkSession) {
       StructField("value", StringType, nullable = false)
     )
   )
+  val schema_nullable: StructType = StructType(
+    Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("ts", IntegerType, nullable = false),
+      StructField("value", StringType, nullable = true)
+    )
+  )
 
   val fg1: DataFrame =
-    spark.createDataFrame(spark.sparkContext.parallelize(DATA_RAW.head), schema)
+    spark.createDataFrame(spark.sparkContext.parallelize(RAW_1), schema)
+  val fg1_with_nulls: DataFrame =
+    spark.createDataFrame(
+      spark.sparkContext.parallelize(RAW_1_WITH_NULLS),
+      schema_nullable
+    )
   val fg2: DataFrame =
-    spark.createDataFrame(spark.sparkContext.parallelize(DATA_RAW(1)), schema)
+    spark.createDataFrame(spark.sparkContext.parallelize(RAW_1), schema)
   val fg3: DataFrame =
-    spark.createDataFrame(spark.sparkContext.parallelize(DATA_RAW(2)), schema)
+    spark.createDataFrame(spark.sparkContext.parallelize(RAW_3), schema)
+  val fg3_with_nulls: DataFrame =
+    spark.createDataFrame(
+      spark.sparkContext.parallelize(RAW_3_WITH_NULLS),
+      schema_nullable
+    )
 
   val empty: DataFrame =
     spark.createDataFrame(spark.sparkContext.emptyRDD[Row], schema)

--- a/scala/src/test/scala/data/SmallDataSortMerge.scala
+++ b/scala/src/test/scala/data/SmallDataSortMerge.scala
@@ -58,13 +58,25 @@ class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
   val PIT_3_1_RAW = Seq(
     Row(2, 8, "f3-2-8", 2, 8, "2y"),
     Row(1, 10, "f3-1-10", 1, 7, "1y"),
-    Row(1, 6, "f3-1-6", 1, 5, "1x"),
+    Row(1, 6, "f3-1-6", 1, 5, "1x")
+  )
+  val PIT_3_1_WITH_NULLS_RAW = Seq(
+    Row(2, 8, null, 2, 8, "2y"),
+    Row(1, 10, "f3-1-10", 1, 7, "1y"),
+    Row(1, 6, "f3-1-6", 1, 5, null)
   )
   val PIT_3_1_OUTER_RAW = Seq(
     Row(2, 8, "f3-2-8", 2, 8, "2y"),
     Row(2, 2, "f3-2-2", null, null, null),
     Row(1, 10, "f3-1-10", 1, 7, "1y"),
     Row(1, 6, "f3-1-6", 1, 5, "1x"),
+    Row(1, 1, "f3-1-1", null, null, null)
+  )
+  val PIT_3_1_WITH_NULLS_OUTER_RAW = Seq(
+    Row(2, 8, null, 2, 8, "2y"),
+    Row(2, 2, "f3-2-2", null, null, null),
+    Row(1, 10, "f3-1-10", 1, 7, "1y"),
+    Row(1, 6, "f3-1-6", 1, 5, null),
     Row(1, 1, "f3-1-1", null, null, null)
   )
   val PIT_1_3_T1_RAW = Seq(
@@ -95,11 +107,31 @@ class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
       StructField("value", StringType, nullable = false)
     )
   )
+  val PIT_2_NULLABLE_schema: StructType = StructType(
+    Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("ts", IntegerType, nullable = false),
+      StructField("value", StringType, nullable = true),
+      StructField("id", IntegerType, nullable = false),
+      StructField("ts", IntegerType, nullable = false),
+      StructField("value", StringType, nullable = true)
+    )
+  )
   val PIT_2_OUTER_schema: StructType = StructType(
     Seq(
       StructField("id", IntegerType, nullable = false),
       StructField("ts", IntegerType, nullable = false),
       StructField("value", StringType, nullable = false),
+      StructField("id", IntegerType, nullable = true),
+      StructField("ts", IntegerType, nullable = true),
+      StructField("value", StringType, nullable = true)
+    )
+  )
+  val PIT_2_NULLABLE_OUTER_schema: StructType = StructType(
+    Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("ts", IntegerType, nullable = false),
+      StructField("value", StringType, nullable = true),
       StructField("id", IntegerType, nullable = true),
       StructField("ts", IntegerType, nullable = true),
       StructField("value", StringType, nullable = true)
@@ -159,6 +191,16 @@ class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
   val PIT_3_1: DataFrame = spark.createDataFrame(
     spark.sparkContext.parallelize(PIT_3_1_RAW),
     PIT_2_OUTER_schema
+  )
+
+  val PIT_3_1_WITH_NULLS: DataFrame = spark.createDataFrame(
+    spark.sparkContext.parallelize(PIT_3_1_WITH_NULLS_RAW),
+    PIT_2_NULLABLE_schema
+  )
+
+  val PIT_3_1_WITH_NULLS_OUTER: DataFrame = spark.createDataFrame(
+    spark.sparkContext.parallelize(PIT_3_1_WITH_NULLS_OUTER_RAW),
+    PIT_2_NULLABLE_OUTER_schema
   )
 
   val PIT_1_2_3: DataFrame = spark.createDataFrame(

--- a/scala/src/test/scala/data/SmallDataSortMerge.scala
+++ b/scala/src/test/scala/data/SmallDataSortMerge.scala
@@ -25,13 +25,13 @@
 package io.github.ackuq.pit
 package data
 
-import org.apache.spark.sql.types.{
-  IntegerType,
-  StringType,
-  StructField,
-  StructType
-}
-import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.types.StringType
+import org.apache.spark.sql.types.StructField
+import org.apache.spark.sql.types.StructType
 
 class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
   val PIT_1_2_RAW = Seq(
@@ -47,6 +47,18 @@ class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
     Row(1, 7, "1y", 1, 6, "f3-1-6"),
     Row(1, 5, "1x", 1, 1, "f3-1-1"),
     Row(1, 4, "1z", 1, 1, "f3-1-1")
+  )
+  val PIT_3_1_RAW = Seq(
+    Row(2, 8, "f3-2-8", 2, 8, "2y"),
+    Row(1, 10, "f3-1-10", 1, 7, "1y"),
+    Row(1, 6, "f3-1-6", 1, 5, "1x"),
+  )
+  val PIT_3_1_OUTER_RAW = Seq(
+    Row(2, 8, "f3-2-8", 2, 8, "2y"),
+    Row(2, 2, "f3-2-2", null, null, null),
+    Row(1, 10, "f3-1-10", 1, 7, "1y"),
+    Row(1, 6, "f3-1-6", 1, 5, "1x"),
+    Row(1, 1, "f3-1-1", null, null, null)
   )
   val PIT_1_3_T1_RAW = Seq(
     Row(2, 8, "2y", 2, 8, "f3-2-8"),
@@ -129,6 +141,16 @@ class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
 
   val PIT_1_3_T1_OUTER: DataFrame = spark.createDataFrame(
     spark.sparkContext.parallelize(PIT_1_3_T1_OUTER_RAW),
+    PIT_2_OUTER_schema
+  )
+
+  val PIT_3_1_OUTER: DataFrame = spark.createDataFrame(
+    spark.sparkContext.parallelize(PIT_3_1_OUTER_RAW),
+    PIT_2_OUTER_schema
+  )
+
+  val PIT_3_1: DataFrame = spark.createDataFrame(
+    spark.sparkContext.parallelize(PIT_3_1_RAW),
     PIT_2_OUTER_schema
   )
 

--- a/scala/src/test/scala/data/SmallDataSortMerge.scala
+++ b/scala/src/test/scala/data/SmallDataSortMerge.scala
@@ -41,6 +41,13 @@ class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
     Row(1, 5, "1x", 1, 5, "1x"),
     Row(1, 4, "1z", 1, 4, "1z")
   )
+  val PIT_1_EMPTY_RAW = Seq(
+    Row(2, 8, "2y", null, null, null),
+    Row(2, 6, "2x", null, null, null),
+    Row(1, 7, "1y", null, null, null),
+    Row(1, 5, "1x", null, null, null),
+    Row(1, 4, "1z", null, null, null)
+  )
   val PIT_1_3_RAW = Seq(
     Row(2, 8, "2y", 2, 8, "f3-2-8"),
     Row(2, 6, "2x", 2, 2, "f3-2-2"),
@@ -157,5 +164,15 @@ class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
   val PIT_1_2_3: DataFrame = spark.createDataFrame(
     spark.sparkContext.parallelize(PIT_1_2_3_RAW),
     PIT_3_schema
+  )
+
+  val PIT_EMPTY: DataFrame = spark.createDataFrame(
+    spark.sparkContext.emptyRDD[Row],
+    PIT_2_schema
+  )
+
+  val PIT_1_EMPTY_OUTER: DataFrame = spark.createDataFrame(
+    spark.sparkContext.parallelize(PIT_1_EMPTY_RAW),
+    PIT_2_OUTER_schema
   )
 }

--- a/scala/src/test/scala/data/SmallDataSortMerge.scala
+++ b/scala/src/test/scala/data/SmallDataSortMerge.scala
@@ -34,40 +34,39 @@ import org.apache.spark.sql.types.{
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 
 class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
-
-  private val PIT_1_2_RAW = Seq(
+  val PIT_1_2_RAW = Seq(
     Row(2, 8, "2y", 2, 8, "2y"),
     Row(2, 6, "2x", 2, 6, "2x"),
     Row(1, 7, "1y", 1, 7, "1y"),
     Row(1, 5, "1x", 1, 5, "1x"),
     Row(1, 4, "1z", 1, 4, "1z")
   )
-  private val PIT_1_3_RAW = Seq(
+  val PIT_1_3_RAW = Seq(
     Row(2, 8, "2y", 2, 8, "f3-2-8"),
     Row(2, 6, "2x", 2, 2, "f3-2-2"),
     Row(1, 7, "1y", 1, 6, "f3-1-6"),
     Row(1, 5, "1x", 1, 1, "f3-1-1"),
     Row(1, 4, "1z", 1, 1, "f3-1-1")
   )
-  private val PIT_1_3_T1_RAW = Seq(
+  val PIT_1_3_T1_RAW = Seq(
     Row(2, 8, "2y", 2, 8, "f3-2-8"),
     Row(1, 7, "1y", 1, 6, "f3-1-6")
   )
-  private val PIT_1_3_T1_OUTER_RAW = Seq(
+  val PIT_1_3_T1_OUTER_RAW = Seq(
     Row(2, 8, "2y", 2, 8, "f3-2-8"),
     Row(2, 6, "2x", null, null, null),
     Row(1, 7, "1y", 1, 6, "f3-1-6"),
     Row(1, 5, "1x", null, null, null),
     Row(1, 4, "1z", null, null, null)
   )
-  private val PIT_1_2_3_RAW = Seq(
+  val PIT_1_2_3_RAW = Seq(
     Row(2, 8, "2y", 2, 8, "2y", 2, 8, "f3-2-8"),
     Row(2, 6, "2x", 2, 6, "2x", 2, 2, "f3-2-2"),
     Row(1, 7, "1y", 1, 7, "1y", 1, 6, "f3-1-6"),
     Row(1, 5, "1x", 1, 5, "1x", 1, 1, "f3-1-1"),
     Row(1, 4, "1z", 1, 4, "1z", 1, 1, "f3-1-1")
   )
-  private val PIT_2_schema: StructType = StructType(
+  val PIT_2_schema: StructType = StructType(
     Seq(
       StructField("id", IntegerType, nullable = false),
       StructField("ts", IntegerType, nullable = false),
@@ -77,7 +76,7 @@ class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
       StructField("value", StringType, nullable = false)
     )
   )
-  private val PIT_2_OUTER_schema: StructType = StructType(
+  val PIT_2_OUTER_schema: StructType = StructType(
     Seq(
       StructField("id", IntegerType, nullable = false),
       StructField("ts", IntegerType, nullable = false),
@@ -88,7 +87,7 @@ class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
     )
   )
 
-  private val PIT_3_schema: StructType = StructType(
+  val PIT_3_schema: StructType = StructType(
     Seq(
       StructField("id", IntegerType, nullable = false),
       StructField("ts", IntegerType, nullable = false),
@@ -99,6 +98,19 @@ class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
       StructField("id", IntegerType, nullable = false),
       StructField("ts", IntegerType, nullable = false),
       StructField("value", StringType, nullable = false)
+    )
+  )
+  val PIT_3_OUTER_schema: StructType = StructType(
+    Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("ts", IntegerType, nullable = false),
+      StructField("value", StringType, nullable = false),
+      StructField("id", IntegerType, nullable = true),
+      StructField("ts", IntegerType, nullable = true),
+      StructField("value", StringType, nullable = true),
+      StructField("id", IntegerType, nullable = true),
+      StructField("ts", IntegerType, nullable = true),
+      StructField("value", StringType, nullable = true)
     )
   )
   val PIT_1_2: DataFrame = spark.createDataFrame(

--- a/scala/src/test/scala/data/SmallDataSortMerge.scala
+++ b/scala/src/test/scala/data/SmallDataSortMerge.scala
@@ -65,11 +65,22 @@ class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
     Row(1, 10, "f3-1-10", 1, 7, "1y"),
     Row(1, 6, "f3-1-6", 1, 5, null)
   )
+  val PIT_3_1_T1_WITH_NULLS_RAW = Seq(
+    Row(2, 8, null, 2, 8, "2y"),
+    Row(1, 6, "f3-1-6", 1, 5, null)
+  )
   val PIT_3_1_OUTER_RAW = Seq(
     Row(2, 8, "f3-2-8", 2, 8, "2y"),
     Row(2, 2, "f3-2-2", null, null, null),
     Row(1, 10, "f3-1-10", 1, 7, "1y"),
     Row(1, 6, "f3-1-6", 1, 5, "1x"),
+    Row(1, 1, "f3-1-1", null, null, null)
+  )
+  val PIT_3_1_T1_WITH_NULLS_OUTER_RAW = Seq(
+    Row(2, 8, null, 2, 8, "2y"),
+    Row(2, 2, "f3-2-2", null, null, null),
+    Row(1, 10, "f3-1-10", null, null, null),
+    Row(1, 6, "f3-1-6", 1, 5, null),
     Row(1, 1, "f3-1-1", null, null, null)
   )
   val PIT_3_1_WITH_NULLS_OUTER_RAW = Seq(
@@ -198,8 +209,18 @@ class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
     PIT_2_NULLABLE_schema
   )
 
+  val PIT_3_1_T1_WITH_NULLS: DataFrame = spark.createDataFrame(
+    spark.sparkContext.parallelize(PIT_3_1_T1_WITH_NULLS_RAW),
+    PIT_2_NULLABLE_schema
+  )
+
   val PIT_3_1_WITH_NULLS_OUTER: DataFrame = spark.createDataFrame(
     spark.sparkContext.parallelize(PIT_3_1_WITH_NULLS_OUTER_RAW),
+    PIT_2_NULLABLE_OUTER_schema
+  )
+
+  val PIT_3_1_T1_WITH_NULLS_OUTER: DataFrame = spark.createDataFrame(
+    spark.sparkContext.parallelize(PIT_3_1_T1_WITH_NULLS_OUTER_RAW),
     PIT_2_NULLABLE_OUTER_schema
   )
 


### PR DESCRIPTION
I found 3 cases where spark PIT produced incorrect output. 

- Refactor the tests a bit to be much more comprehensive. We now test every combination I can think of and every test runs both codegen and interpreted. 
- Fix all the failures:
  - [codegen__left_join_some_rows_have_no_backwards_match](https://github.com/Tom-Newton/spark-pit/pull/5/commits/4509aa36e4d04a857d59e6651fe2b2665e6be82a)
  - [interpreted__left_join_right_dataframe_is_empty](https://github.com/Tom-Newton/spark-pit/pull/5/commits/d290fd1f3129f3216f56035ddeef201399be67d2)
  - [interpretted__inner_join_searching_backward_for_matches_with_tolerance](https://github.com/Tom-Newton/spark-pit/pull/5/commits/2a0bd3901ae23165d67731619a18e7a94091a005)