### PR TITLE
Refactor interpreted code path + fix nulls in join keys

### DIFF
--- a/scala/src/main/scala/execution/PITJoinExec.scala
+++ b/scala/src/main/scala/execution/PITJoinExec.scala
@@ -204,10 +204,10 @@ protected[pit] case class PITJoinExec(
               new GenericInternalRow(right.output.length)
 
             override def advanceNext(): Boolean = {
-              while (smjScanner.findNextJoinRows()) {
+              if (smjScanner.findNextJoinRows()) {
                 currentRightMatch = smjScanner.getBufferedMatch
                 currentLeftRow = smjScanner.getStreamedRow
-                if (returnNulls && currentRightMatch == null) {
+                if (currentRightMatch == null) {
                   joinRow(currentLeftRow, nullRightRow)
                   joinRow.withRight(nullRightRow)
                   numOutputRows += 1
@@ -220,9 +220,6 @@ protected[pit] case class PITJoinExec(
                   }
                 }
               }
-
-              currentRightMatch = null
-              currentLeftRow = null
               false
             }
 
@@ -852,7 +849,6 @@ protected[pit] class PITJoinScanner(
       streamedRow = streamedIter.getRow
       streamedRowEquiKey = streamedEquiKeyGenerator(streamedRow)
       streamedRowPITKey = streamedPITKeyGenerator(streamedRow)
-      bufferedMatch = null
       true
     } else {
       streamedRow = null

--- a/scala/src/main/scala/execution/PITJoinExec.scala
+++ b/scala/src/main/scala/execution/PITJoinExec.scala
@@ -147,19 +147,7 @@ protected[pit] case class PITJoinExec(
     val numOutputRows = longMetric("numOutputRows")
 
     left.execute().zipPartitions(right.execute()) { (leftIter, rightIter) =>
-      val boundCondition: InternalRow => Boolean = {
-        condition
-          .map { cond =>
-            Predicate.create(cond, left.output ++ right.output).eval _
-
-          }
-          .getOrElse { (r: InternalRow) =>
-            true
-          }
-      }
-
       // An ordering that can be used to compare keys from both sides.
-
       // Ordering of the equi-keys
       val equiOrder: Seq[SortOrder] =
         leftEquiKeys.map(_.dataType).zipWithIndex.map { case (dt, index) =>
@@ -214,10 +202,8 @@ protected[pit] case class PITJoinExec(
                   return true
                 } else {
                   joinRow(currentLeftRow, currentRightMatch)
-                  if (boundCondition(joinRow)) {
-                    numOutputRows += 1
-                    return true
-                  }
+                  numOutputRows += 1
+                  return true
                 }
               }
               false

--- a/scala/src/main/scala/execution/PITJoinExec.scala
+++ b/scala/src/main/scala/execution/PITJoinExec.scala
@@ -750,16 +750,15 @@ protected[pit] class PITJoinScanner(
     // Advance the `leftRow` at the start of every call to avoid returning the same rows repeatedly.
     val leftIteratorNotEmpty = advancedLeft()
     val rightIteratorNotEmpty = rightRow != null
-    // If there is at least one more row in both iterators keepSearching,
     var keepSearchingPotentiallyMoreJoinRows: (Boolean, Boolean) =
       (
-        // If both iterators are non empty then searching might find a match
+        // If both iterators are non-empty then searching might find a match - keep searching.
         leftIteratorNotEmpty && rightIteratorNotEmpty,
-        // For more join rows the left iterator must be non empty and either returnNulls is allowed or
-        // the right iterator is non empty.
+        // For more join rows the left iterator must be non-empty and either returnNulls is allowed or
+        // the right iterator is non-empty.
         leftIteratorNotEmpty && (returnNulls || rightIteratorNotEmpty)
       )
-    // This might require advancing both iterators.
+    // Run the search. If not returnNulls this might require advancing both iterators.
     while (keepSearchingPotentiallyMoreJoinRows._1) {
       keepSearchingPotentiallyMoreJoinRows = {
         if (leftRowPITKey.anyNull || leftRowEquiKey.anyNull) {

--- a/scala/src/main/scala/execution/PITJoinExec.scala
+++ b/scala/src/main/scala/execution/PITJoinExec.scala
@@ -677,10 +677,11 @@ protected[pit] case class PITJoinExec(
   }
 }
 
+// TODO: Update this comment
 /** Helper class that is used to implement [[PITJoinExec]].
   *
-  * To perform an inner (outer) join, users of this class call
-  * [[findNextInnerJoinRows()]] which returns `true` if a result has been
+  * To perform an inner or left join, users of this class call
+  * [[findNextJoinRows()]]. This returns `true` if a result has been
   * produced and `false` otherwise. If a result has been produced, then the
   * caller may call [[getStreamedRow]] to return the matching row from the
   * streamed input For efficiency, both of these methods return mutable objects
@@ -742,8 +743,6 @@ protected[pit] class PITJoinScanner(
   // --- Public methods ---------------------------------------------------------------------------
 
   def getStreamedRow: InternalRow = streamedRow
-
-  def getBufferedRow: InternalRow = bufferedRow
 
   def getBufferedMatch: UnsafeRow = bufferedMatch
 

--- a/scala/src/main/scala/execution/PITJoinExec.scala
+++ b/scala/src/main/scala/execution/PITJoinExec.scala
@@ -747,7 +747,7 @@ protected[pit] class PITJoinScanner(
     * returnNulls it will always return a result for every left row so it will
     * only advance the right iterator when searching. If not returnNulls it will
     * may advance both iterators when searching for a match. When there are no
-    * more potential matches it does eager cleanup. 
+    * more potential matches it does eager cleanup.
     * @return
     *   true if matching rows have been found and false otherwise. If this
     *   returns true, then [[getLeftRow]] and [[getRightMatch]] can be called to

--- a/scala/src/main/scala/execution/PITJoinExec.scala
+++ b/scala/src/main/scala/execution/PITJoinExec.scala
@@ -474,12 +474,6 @@ protected[pit] case class PITJoinExec(
     //            For `leftRow` without `match`:
     //            1. Inner join: skip this `leftRow` the row, and try the next one.
     //            2. Left Outer join: keep the row and return false with null `match`.
-
-    // Exit reasons:
-    // 1. Either of the iterators is exhausted.
-    // 2. A match is found.
-    // 3. Left join and no match possible for this `leftRow`.
-
     ctx.addNewFunction(
       "findNextJoinRows",
       s"""

--- a/scala/src/main/scala/execution/PITJoinExec.scala
+++ b/scala/src/main/scala/execution/PITJoinExec.scala
@@ -670,7 +670,6 @@ protected[pit] case class PITJoinExec(
   }
 }
 
-// TODO: Update this comment
 /** Helper class that is used to implement [[PITJoinExec]].
   *
   * To perform an inner or outer join, users of this class call

--- a/scala/src/test/scala/EarlyStopMergeTests.scala
+++ b/scala/src/test/scala/EarlyStopMergeTests.scala
@@ -80,7 +80,7 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
 
     expectedDataFrame.show()
 
-    // assert(pitJoin.schema.equals(expectedSchema))
+    assert(pitJoin.schema.equals(expectedSchema))
     assert(pitJoin.collect().sameElements(expectedDataFrame.collect()))
   }
 
@@ -391,7 +391,7 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
       smallData.fg1_duplicates,
       smallData.fg3_duplicates,
       smallData.PIT_1_3_DUPLICATES,
-      smallData.PIT_2_schema,
+      smallData.PIT_2_OUTER_schema,
       0
     )
   }

--- a/scala/src/test/scala/EarlyStopMergeTests.scala
+++ b/scala/src/test/scala/EarlyStopMergeTests.scala
@@ -349,7 +349,7 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
       "inner",
       smallData.fg1_with_key_nulls,
       smallData.fg3_with_key_nulls,
-      smallData.PIT_1_WITH_KEY_NULLS_3,
+      smallData.PIT_1_3_WITH_KEY_NULLS,
       smallData.PIT_2_schema,
       0
     )
@@ -361,8 +361,8 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
     testSearchingBackwardForMatches(
       "left",
       smallData.fg1_with_key_nulls,
-      smallData.fg3,
-      smallData.PIT_1_WITH_KEY_NULLS_3,
+      smallData.fg3_with_key_nulls,
+      smallData.PIT_1_3_WITH_KEY_NULLS_OUTER,
       smallData.PIT_2_schema,
       0
     )

--- a/scala/src/test/scala/EarlyStopMergeTests.scala
+++ b/scala/src/test/scala/EarlyStopMergeTests.scala
@@ -352,7 +352,10 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
       smallData.fg1_with_key_nulls,
       smallData.fg3_with_key_nulls,
       smallData.PIT_1_3_WITH_KEY_NULLS,
-      smallData.PIT_2_schema,
+      // It could be argued the correct schema would be `smallData.PIT_2_schema`, 
+      // i.e. with join key columns made non-nullable. However, the normal spark inner
+      // join does not do this, so we don't either.
+      smallData.PIT_2_NULLABLE_KEYS_schema,
       0
     )
   }
@@ -365,7 +368,7 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
       smallData.fg1_with_key_nulls,
       smallData.fg3_with_key_nulls,
       smallData.PIT_1_3_WITH_KEY_NULLS_OUTER,
-      smallData.PIT_2_schema,
+      smallData.PIT_2_NULLABLE_KEYS_OUTER_schema,
       0
     )
   }

--- a/scala/src/test/scala/EarlyStopMergeTests.scala
+++ b/scala/src/test/scala/EarlyStopMergeTests.scala
@@ -74,11 +74,13 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
         joinType
       )
 
-    pitJoin.show()
+    pitJoin.explain("codegen")
     pitJoin.printSchema()
+    pitJoin.show()
+
     expectedDataFrame.show()
 
-    assert(pitJoin.schema.equals(expectedSchema))
+    // assert(pitJoin.schema.equals(expectedSchema))
     assert(pitJoin.collect().sameElements(expectedDataFrame.collect()))
   }
 
@@ -343,7 +345,7 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
   }
 
   testBothCodegenAndInterpreted(
-    "inner_join_left_has_nulls_in_join_keys"
+    "inner_join_nulls_in_join_keys"
   ) {
     testSearchingBackwardForMatches(
       "inner",
@@ -356,13 +358,39 @@ class EarlyStopMergeTests extends AnyFlatSpec with SparkSessionTestWrapper {
   }
 
   testBothCodegenAndInterpreted(
-    "left_join_left_has_nulls_in_join_key"
+    "left_join_nulls_in_join_key"
   ) {
     testSearchingBackwardForMatches(
       "left",
       smallData.fg1_with_key_nulls,
       smallData.fg3_with_key_nulls,
       smallData.PIT_1_3_WITH_KEY_NULLS_OUTER,
+      smallData.PIT_2_schema,
+      0
+    )
+  }
+
+  testBothCodegenAndInterpreted(
+    "inner_join_duplicate_join_keys"
+  ) {
+    testSearchingBackwardForMatches(
+      "inner",
+      smallData.fg1_duplicates,
+      smallData.fg3_duplicates,
+      smallData.PIT_1_3_DUPLICATES,
+      smallData.PIT_2_schema,
+      0
+    )
+  }
+
+  testBothCodegenAndInterpreted(
+    "left_join_duplicate_join_keys"
+  ) {
+    testSearchingBackwardForMatches(
+      "left",
+      smallData.fg1_duplicates,
+      smallData.fg3_duplicates,
+      smallData.PIT_1_3_DUPLICATES,
       smallData.PIT_2_schema,
       0
     )

--- a/scala/src/test/scala/data/SmallData.scala
+++ b/scala/src/test/scala/data/SmallData.scala
@@ -41,6 +41,18 @@ class SmallData(spark: SparkSession) {
     Row(1, 7, "1y"),
     Row(2, 8, "2y")
   )
+  val RAW_1_DUPLICTES = Seq(
+    Row(1, 4, "1z"),
+    Row(1, 4, "1z"),
+    Row(1, 5, "1x"),
+    Row(1, 5, "1x"),
+    Row(2, 6, "2x"),
+    Row(2, 6, "2x"),
+    Row(1, 7, "1y"),
+    Row(1, 7, "1y"),
+    Row(2, 8, "2y"),
+    Row(2, 8, "2y")
+  )
   val RAW_1_WITH_VALUE_NULLS = Seq(
     Row(1, 4, "1z"),
     Row(1, 5, null),
@@ -60,6 +72,18 @@ class SmallData(spark: SparkSession) {
     Row(2, 2, "f3-2-2"),
     Row(1, 6, "f3-1-6"),
     Row(2, 8, "f3-2-8"),
+    Row(1, 10, "f3-1-10")
+  )
+  val RAW_3_DUPLICATES = Seq(
+    Row(1, 1, "f3-1-1"),
+    Row(1, 1, "f3-1-1"),
+    Row(2, 2, "f3-2-2"),
+    Row(2, 2, "f3-2-2"),
+    Row(1, 6, "f3-1-6"),
+    Row(1, 6, "f3-1-6"),
+    Row(2, 8, "f3-2-8"),
+    Row(2, 8, "f3-2-8"),
+    Row(1, 10, "f3-1-10"),
     Row(1, 10, "f3-1-10")
   )
   val RAW_3_WITH_VALUE_NULLS = Seq(
@@ -101,6 +125,8 @@ class SmallData(spark: SparkSession) {
 
   val fg1: DataFrame =
     spark.createDataFrame(spark.sparkContext.parallelize(RAW_1), schema)
+  val fg1_duplicates: DataFrame =
+    spark.createDataFrame(spark.sparkContext.parallelize(RAW_1_DUPLICTES), schema)
   val fg1_with_value_nulls: DataFrame =
     spark.createDataFrame(
       spark.sparkContext.parallelize(RAW_1_WITH_VALUE_NULLS),
@@ -115,6 +141,8 @@ class SmallData(spark: SparkSession) {
     spark.createDataFrame(spark.sparkContext.parallelize(RAW_1), schema)
   val fg3: DataFrame =
     spark.createDataFrame(spark.sparkContext.parallelize(RAW_3), schema)
+  val fg3_duplicates: DataFrame =
+    spark.createDataFrame(spark.sparkContext.parallelize(RAW_3_DUPLICATES), schema)
   val fg3_with_value_nulls: DataFrame =
     spark.createDataFrame(
       spark.sparkContext.parallelize(RAW_3_WITH_VALUE_NULLS),

--- a/scala/src/test/scala/data/SmallData.scala
+++ b/scala/src/test/scala/data/SmallData.scala
@@ -41,12 +41,19 @@ class SmallData(spark: SparkSession) {
     Row(1, 7, "1y"),
     Row(2, 8, "2y")
   )
-  val RAW_1_WITH_NULLS = Seq(
+  val RAW_1_WITH_VALUE_NULLS = Seq(
     Row(1, 4, "1z"),
     Row(1, 5, null),
     Row(2, 6, "2x"),
     Row(1, 7, "1y"),
     Row(2, 8, "2y")
+  )
+  val RAW_1_WITH_KEY_NULLS = Seq(
+    Row(1, 4, "1z"),
+    Row(1, null, "1x"),
+    Row(2, 6, "2x"),
+    Row(1, 7, "1y"),
+    Row(null, 8, "2y")
   )
   val RAW_3 = Seq(
     Row(1, 1, "f3-1-1"),
@@ -55,11 +62,18 @@ class SmallData(spark: SparkSession) {
     Row(2, 8, "f3-2-8"),
     Row(1, 10, "f3-1-10")
   )
-  val RAW_3_WITH_NULLS = Seq(
+  val RAW_3_WITH_VALUE_NULLS = Seq(
     Row(1, 1, "f3-1-1"),
     Row(2, 2, "f3-2-2"),
     Row(1, 6, "f3-1-6"),
     Row(2, 8, null),
+    Row(1, 10, "f3-1-10")
+  )
+  val RAW_3_WITH_KEY_NULLS = Seq(
+    Row(1, 1, "f3-1-1"),
+    Row(2, null, "f3-2-2"),
+    Row(null, 6, "f3-1-6"),
+    Row(2, 8, "f3-2-8"),
     Row(1, 10, "f3-1-10")
   )
   val schema: StructType = StructType(
@@ -69,7 +83,7 @@ class SmallData(spark: SparkSession) {
       StructField("value", StringType, nullable = false)
     )
   )
-  val schema_nullable: StructType = StructType(
+  val schema_value_nullable: StructType = StructType(
     Seq(
       StructField("id", IntegerType, nullable = false),
       StructField("ts", IntegerType, nullable = false),
@@ -77,21 +91,39 @@ class SmallData(spark: SparkSession) {
     )
   )
 
+  val schema_keys_nullable: StructType = StructType(
+    Seq(
+      StructField("id", IntegerType, nullable = true),
+      StructField("ts", IntegerType, nullable = true),
+      StructField("value", StringType, nullable = false)
+    )
+  )
+
   val fg1: DataFrame =
     spark.createDataFrame(spark.sparkContext.parallelize(RAW_1), schema)
-  val fg1_with_nulls: DataFrame =
+  val fg1_with_value_nulls: DataFrame =
     spark.createDataFrame(
-      spark.sparkContext.parallelize(RAW_1_WITH_NULLS),
-      schema_nullable
+      spark.sparkContext.parallelize(RAW_1_WITH_VALUE_NULLS),
+      schema_value_nullable
+    )
+  val fg1_with_key_nulls: DataFrame =
+    spark.createDataFrame(
+      spark.sparkContext.parallelize(RAW_1_WITH_KEY_NULLS),
+      schema_keys_nullable
     )
   val fg2: DataFrame =
     spark.createDataFrame(spark.sparkContext.parallelize(RAW_1), schema)
   val fg3: DataFrame =
     spark.createDataFrame(spark.sparkContext.parallelize(RAW_3), schema)
-  val fg3_with_nulls: DataFrame =
+  val fg3_with_value_nulls: DataFrame =
     spark.createDataFrame(
-      spark.sparkContext.parallelize(RAW_3_WITH_NULLS),
-      schema_nullable
+      spark.sparkContext.parallelize(RAW_3_WITH_VALUE_NULLS),
+      schema_value_nullable
+    )
+  val fg3_with_key_nulls: DataFrame =
+    spark.createDataFrame(
+      spark.sparkContext.parallelize(RAW_3_WITH_KEY_NULLS),
+      schema_keys_nullable
     )
 
   val empty: DataFrame =

--- a/scala/src/test/scala/data/SmallDataSortMerge.scala
+++ b/scala/src/test/scala/data/SmallDataSortMerge.scala
@@ -151,6 +151,18 @@ class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
       StructField("value", StringType, nullable = true)
     )
   )
+
+  val PIT_2_NULLABLE_KEYS_schema: StructType = StructType(
+    Seq(
+      StructField("id", IntegerType, nullable = true),
+      StructField("ts", IntegerType, nullable = true),
+      StructField("value", StringType, nullable = false),
+      StructField("id", IntegerType, nullable = true),
+      StructField("ts", IntegerType, nullable = true),
+      StructField("value", StringType, nullable = false)
+    )
+  )
+
   val PIT_2_OUTER_schema: StructType = StructType(
     Seq(
       StructField("id", IntegerType, nullable = false),

--- a/scala/src/test/scala/data/SmallDataSortMerge.scala
+++ b/scala/src/test/scala/data/SmallDataSortMerge.scala
@@ -55,17 +55,21 @@ class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
     Row(1, 5, "1x", 1, 1, "f3-1-1"),
     Row(1, 4, "1z", 1, 1, "f3-1-1")
   )
+  val PIT_1_WITH_KEY_NULLS_3_RAW = Seq(
+    Row(1, 7, "1y", 1, 1, "f3-1-1"),
+    Row(1, 4, "1z", 1, 1, "f3-1-1")
+  )
   val PIT_3_1_RAW = Seq(
     Row(2, 8, "f3-2-8", 2, 8, "2y"),
     Row(1, 10, "f3-1-10", 1, 7, "1y"),
     Row(1, 6, "f3-1-6", 1, 5, "1x")
   )
-  val PIT_3_1_WITH_NULLS_RAW = Seq(
+  val PIT_3_1_WITH_VALUE_NULLS_RAW = Seq(
     Row(2, 8, null, 2, 8, "2y"),
     Row(1, 10, "f3-1-10", 1, 7, "1y"),
     Row(1, 6, "f3-1-6", 1, 5, null)
   )
-  val PIT_3_1_T1_WITH_NULLS_RAW = Seq(
+  val PIT_3_1_T1_WITH_VALUE_NULLS_RAW = Seq(
     Row(2, 8, null, 2, 8, "2y"),
     Row(1, 6, "f3-1-6", 1, 5, null)
   )
@@ -76,14 +80,14 @@ class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
     Row(1, 6, "f3-1-6", 1, 5, "1x"),
     Row(1, 1, "f3-1-1", null, null, null)
   )
-  val PIT_3_1_T1_WITH_NULLS_OUTER_RAW = Seq(
+  val PIT_3_1_T1_WITH_VALUE_NULLS_OUTER_RAW = Seq(
     Row(2, 8, null, 2, 8, "2y"),
     Row(2, 2, "f3-2-2", null, null, null),
     Row(1, 10, "f3-1-10", null, null, null),
     Row(1, 6, "f3-1-6", 1, 5, null),
     Row(1, 1, "f3-1-1", null, null, null)
   )
-  val PIT_3_1_WITH_NULLS_OUTER_RAW = Seq(
+  val PIT_3_1_WITH_VALUE_NULLS_OUTER_RAW = Seq(
     Row(2, 8, null, 2, 8, "2y"),
     Row(2, 2, "f3-2-2", null, null, null),
     Row(1, 10, "f3-1-10", 1, 7, "1y"),
@@ -184,6 +188,11 @@ class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
     PIT_2_schema
   )
 
+  val PIT_1_WITH_KEY_NULLS_3: DataFrame = spark.createDataFrame(
+    spark.sparkContext.parallelize(PIT_1_WITH_KEY_NULLS_3_RAW),
+    PIT_2_schema
+  )
+
   val PIT_1_3_T1: DataFrame = spark.createDataFrame(
     spark.sparkContext.parallelize(PIT_1_3_T1_RAW),
     PIT_2_schema
@@ -205,22 +214,22 @@ class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
   )
 
   val PIT_3_1_WITH_NULLS: DataFrame = spark.createDataFrame(
-    spark.sparkContext.parallelize(PIT_3_1_WITH_NULLS_RAW),
+    spark.sparkContext.parallelize(PIT_3_1_WITH_VALUE_NULLS_RAW),
     PIT_2_NULLABLE_schema
   )
 
   val PIT_3_1_T1_WITH_NULLS: DataFrame = spark.createDataFrame(
-    spark.sparkContext.parallelize(PIT_3_1_T1_WITH_NULLS_RAW),
+    spark.sparkContext.parallelize(PIT_3_1_T1_WITH_VALUE_NULLS_RAW),
     PIT_2_NULLABLE_schema
   )
 
   val PIT_3_1_WITH_NULLS_OUTER: DataFrame = spark.createDataFrame(
-    spark.sparkContext.parallelize(PIT_3_1_WITH_NULLS_OUTER_RAW),
+    spark.sparkContext.parallelize(PIT_3_1_WITH_VALUE_NULLS_OUTER_RAW),
     PIT_2_NULLABLE_OUTER_schema
   )
 
   val PIT_3_1_T1_WITH_NULLS_OUTER: DataFrame = spark.createDataFrame(
-    spark.sparkContext.parallelize(PIT_3_1_T1_WITH_NULLS_OUTER_RAW),
+    spark.sparkContext.parallelize(PIT_3_1_T1_WITH_VALUE_NULLS_OUTER_RAW),
     PIT_2_NULLABLE_OUTER_schema
   )
 

--- a/scala/src/test/scala/data/SmallDataSortMerge.scala
+++ b/scala/src/test/scala/data/SmallDataSortMerge.scala
@@ -55,9 +55,16 @@ class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
     Row(1, 5, "1x", 1, 1, "f3-1-1"),
     Row(1, 4, "1z", 1, 1, "f3-1-1")
   )
-  val PIT_1_WITH_KEY_NULLS_3_RAW = Seq(
+  val PIT_1_3_WITH_KEY_NULLS_RAW = Seq(
     Row(1, 7, "1y", 1, 1, "f3-1-1"),
     Row(1, 4, "1z", 1, 1, "f3-1-1")
+  )
+  val PIT_1_3_WITH_KEY_NULLS_OUTER_RAW = Seq(
+    Row(2, 6, "2x", null, null, null),
+    Row(1, 7, "1y", 1, 1, "f3-1-1"),
+    Row(1, 4, "1z", 1, 1, "f3-1-1"),
+    Row(1, null, "1x", null, null, null),
+    Row(null, 8, "2y", null, null, null)
   )
   val PIT_3_1_RAW = Seq(
     Row(2, 8, "f3-2-8", 2, 8, "2y"),
@@ -153,6 +160,17 @@ class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
     )
   )
 
+  val PIT_2_NULLABLE_KEYS_OUTER_schema: StructType = StructType(
+    Seq(
+      StructField("id", IntegerType, nullable = true),
+      StructField("ts", IntegerType, nullable = true),
+      StructField("value", StringType, nullable = false),
+      StructField("id", IntegerType, nullable = true),
+      StructField("ts", IntegerType, nullable = true),
+      StructField("value", StringType, nullable = true)
+    )
+  )
+
   val PIT_3_schema: StructType = StructType(
     Seq(
       StructField("id", IntegerType, nullable = false),
@@ -188,9 +206,14 @@ class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
     PIT_2_schema
   )
 
-  val PIT_1_WITH_KEY_NULLS_3: DataFrame = spark.createDataFrame(
-    spark.sparkContext.parallelize(PIT_1_WITH_KEY_NULLS_3_RAW),
+  val PIT_1_3_WITH_KEY_NULLS: DataFrame = spark.createDataFrame(
+    spark.sparkContext.parallelize(PIT_1_3_WITH_KEY_NULLS_RAW),
     PIT_2_schema
+  )
+
+  val PIT_1_3_WITH_KEY_NULLS_OUTER: DataFrame = spark.createDataFrame(
+    spark.sparkContext.parallelize(PIT_1_3_WITH_KEY_NULLS_OUTER_RAW),
+    PIT_2_NULLABLE_KEYS_OUTER_schema
   )
 
   val PIT_1_3_T1: DataFrame = spark.createDataFrame(

--- a/scala/src/test/scala/data/SmallDataSortMerge.scala
+++ b/scala/src/test/scala/data/SmallDataSortMerge.scala
@@ -55,6 +55,18 @@ class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
     Row(1, 5, "1x", 1, 1, "f3-1-1"),
     Row(1, 4, "1z", 1, 1, "f3-1-1")
   )
+  val PIT_1_3_DUPLICATES_RAW = Seq(
+    Row(2, 8, "2y", 2, 8, "f3-2-8"),
+    Row(2, 8, "2y", 2, 8, "f3-2-8"),
+    Row(2, 6, "2x", 2, 2, "f3-2-2"),
+    Row(2, 6, "2x", 2, 2, "f3-2-2"),
+    Row(1, 7, "1y", 1, 6, "f3-1-6"),
+    Row(1, 7, "1y", 1, 6, "f3-1-6"),
+    Row(1, 5, "1x", 1, 1, "f3-1-1"),
+    Row(1, 5, "1x", 1, 1, "f3-1-1"),
+    Row(1, 4, "1z", 1, 1, "f3-1-1"),
+    Row(1, 4, "1z", 1, 1, "f3-1-1")
+  )
   val PIT_1_3_WITH_KEY_NULLS_RAW = Seq(
     Row(1, 7, "1y", 1, 1, "f3-1-1"),
     Row(1, 4, "1z", 1, 1, "f3-1-1")
@@ -203,6 +215,10 @@ class SmallDataSortMerge(spark: SparkSession) extends SmallData(spark) {
   )
   val PIT_1_3: DataFrame = spark.createDataFrame(
     spark.sparkContext.parallelize(PIT_1_3_RAW),
+    PIT_2_schema
+  )
+  val PIT_1_3_DUPLICATES: DataFrame = spark.createDataFrame(
+    spark.sparkContext.parallelize(PIT_1_3_DUPLICATES_RAW),
     PIT_2_schema
   )
 


### PR DESCRIPTION
- Added some more tests around nulls in the join keys and duplicate input rows. 
  - Fixed both codegen and interpreted code paths for nulls in join keys. 
- Refactor interpreted code path.
  - Remove lots of legacy from the normal spark sort merge join related to buffering multiple matches for each streamed row. With the PIT join we only allow one match per left row (this does create some non-determinism if there are duplicate input rows). 
- Update comments and renamed lots of variables
  - Rename `streamed` -> `left` and `buffered` -> `right`.  Streamed and buffered only really made sense in the normal sort merge join because of the buffering multiple matches thing. Additionally in the PIT join the left and right dataframes are considered fundamentally different. 