### PR TITLE
Update pyspark requirement

### DIFF
--- a/python/requirements_common.txt
+++ b/python/requirements_common.txt
@@ -1,3 +1,3 @@
 # Common requirements used for all environments
 
-pyspark==3.2.1
+pyspark==3.5.0


### PR DESCRIPTION
This is un-important since 3.2.1 and 3.5.0 are the similar enough on the python side that it makes no different to `spark-pit`. Its definitely still a good thing to keep the scala and python version in sync. 