### PR TITLE
Fully remove non equi non pit condition

### DIFF
--- a/scala/src/main/scala/execution/Patterns.scala
+++ b/scala/src/main/scala/execution/Patterns.scala
@@ -109,10 +109,9 @@ object PITJoinExtractEquality extends ExtractEqualityKeys {
     val equiJoinKeys = getEquiJoinKeys(predicates, join.left, join.right)
 
     if (predicates.length != equiJoinKeys.length) {
-      logDebug(
-        s"Could not extract all equi-join keys from join condition: ${join.condition}"
+      throw new IllegalArgumentException(
+        "Besides the PIT key, only equi-conditions are supported for PIT joins"
       )
-      return None
     }
     val leftPitKey =
       if (canEvaluate(join.pitCondition.children.head, join.left))

--- a/scala/src/main/scala/execution/Patterns.scala
+++ b/scala/src/main/scala/execution/Patterns.scala
@@ -135,7 +135,7 @@ object PITJoinExtractEquality extends ExtractEqualityKeys {
         rightPitKey,
         leftEquiKeys,
         rightEquiKeys,
-        otherPredicates.reduceOption(And),
+        None,
         join.returnNulls,
         join.tolerance,
         join.left,

--- a/scala/src/main/scala/execution/Patterns.scala
+++ b/scala/src/main/scala/execution/Patterns.scala
@@ -108,13 +108,11 @@ object PITJoinExtractEquality extends ExtractEqualityKeys {
     // These need to be sortable in order to make the algorithm work optimized
     val equiJoinKeys = getEquiJoinKeys(predicates, join.left, join.right)
 
-    val otherPredicates = predicates.filterNot {
-      case EqualTo(l, r) if l.references.isEmpty || r.references.isEmpty =>
-        false
-      case Equality(l, r) =>
-        canEvaluate(l, join.left) && canEvaluate(r, join.right) ||
-        canEvaluate(l, join.right) && canEvaluate(r, join.left)
-      case _ => false
+    if (predicates.length != equiJoinKeys.length) {
+      logDebug(
+        s"Could not extract all equi-join keys from join condition: ${join.condition}"
+      )
+      return None
     }
     val leftPitKey =
       if (canEvaluate(join.pitCondition.children.head, join.left))


### PR DESCRIPTION
Spark PIT does not support non-equi conditions beside the PIT column.

- Make this more explicit by failing during query plan
- Remove some unneeded code designed to handle these during execution. I assume this is more legacy of the original sort merge join. 
- Add a test asserting a failure